### PR TITLE
fix spacing issues under images

### DIFF
--- a/source/stylesheets/modules/_article.css.sass
+++ b/source/stylesheets/modules/_article.css.sass
@@ -37,6 +37,9 @@
       overflow: hidden
       display: flex
 
+      img
+        display: block
+
       figure
         padding-left: 10px
 


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/1215495/15325932/58d901ae-1c4c-11e6-9c6d-a44597834633.png)

After:
![image](https://cloud.githubusercontent.com/assets/1215495/15325922/53c3e1ca-1c4c-11e6-962e-f9d3aa8b9fe1.png)
